### PR TITLE
Fix action.yml input definition.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: 'Auto-assign Issue'
 description: 'Auto-assigns issues to users'
 inputs:
+    repo-token:
+        description: 'The GITHUB_TOKEN, neede to update the Issue'
+        required: true
     assignees:
         description: 'Comma separated list of user names'
         required: true


### PR DESCRIPTION
Because the repo-token was not defined in
action.yml using the action will trigger
a warning.