### PR TITLE
fix: octokit instance is now grabbed using a function call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const github = require('@actions/github');
 const run = async () => {
     // Get octokit
     const gitHubToken = core.getInput('repo-token', { required: true });
-    const octokit = new github.GitHub(gitHubToken);
+    const octokit = github.getOctokit(gitHubToken);
 
     // Get repo and issue info
     const { repository, issue } = github.context.payload;


### PR DESCRIPTION
As mention in [this issue](#6 ), The action has stopped working, throwing the following (but not failing the workflow):

```text
(node:2419) UnhandledPromiseRejectionWarning: TypeError: github.GitHub is not a constructor
    at run (/home/runner/work/_actions/pozil/auto-assign-issue/v1.0.2/src/index.js:7:21)
    at Object.<anonymous> (/home/runner/work/_actions/pozil/auto-assign-issue/v1.0.2/src/index.js:39:5)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at Module.load (internal/modules/cjs/loader.js:815:32)
    at Function.Module._load (internal/modules/cjs/loader.js:727:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1047:10)
    at internal/main/run_main_module.js:17:11
(node:2419) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:2419) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

There are two issues to be addressed here if I understand this correctly.
The first issue, **fixed in this PR** is the cause for the error:

```text
TypeError: github.GitHub is not a constructor
```

As you can see in [this commit](https://github.com/actions/toolkit/commit/4a89cf72de68713d3a465254e90537d8ea5b421e) for `@actions/github`:
[the concrete class `GitHub` extending `Octokit` is removed](https://github.com/actions/toolkit/commit/4a89cf72de68713d3a465254e90537d8ea5b421e#diff-90fa39202b2443e6608f1455a9ad340d0dd924bbe910c5440944d0e817725212L22).
[An `Octokit` instance is now grabbed using the `getOctokit` function](https://github.com/actions/toolkit/commit/4a89cf72de68713d3a465254e90537d8ea5b421e#diff-90fa39202b2443e6608f1455a9ad340d0dd924bbe910c5440944d0e817725212R15).
It is of course also updated in the [README file updated in the same commit](https://github.com/actions/toolkit/commit/4a89cf72de68713d3a465254e90537d8ea5b421e#diff-a9d710d08a33ec757446944f7c9ff36afbc668170cb7de53490208732171d300L20).

The second issue to be addressed, **not fixed in this PR** is the deprecation notice:

```text
(node:2419) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:2419) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

If I understand this correctly, the reason for the original error not failing the build is exactly what is being addressed in the deprecation notice.
The currently failing instantiation of the `Github` class, is failing inside an `async function` and should be caught and used in conjunction with `core.setFailed`.

But that's outside the scope of the PR for now (maybe for the next one).
This PR should close (at least one aspect of) #6 .