### PR TITLE
Add default GitHub token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Auto-assigns issues to users'
 inputs:
     repo-token:
         description: 'The GITHUB_TOKEN, needed to update the Issue'
-        required: true
+        default: ${{ github.token }}
     assignees:
         description: 'Comma separated list of user names'
         required: true


### PR DESCRIPTION
GitHub Actions can contribute a default value for the `repo-token` input by specifying `default: ${{github.token}}` removing the need for the extra boilerplate that users must add to their workflows.  This technique is used in many of the GitHub created actions such as checkout, setup-node, stale, etc.

- https://github.com/actions/checkout/blob/main/action.yml#L24
- https://github.com/actions/setup-node/blob/main/action.yml#L21
- https://github.com/actions/stale/blob/main/action.yml#L8