### PR TITLE
Fix octokit bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 ## Inputs
 
-| Parameter    | Required | Description                                                                |
-| ------------ | -------- | -------------------------------------------------------------------------- |
-| `repo-token` | true     | The GITHUB_TOKEN, needed to update the Issue.                              |
-| `assignees`  | true     | Comma separated list of user names. Issue will be assigned to those users. |
+| Parameter   | Required | Description                                                                |
+| ----------- | -------- | -------------------------------------------------------------------------- |
+| `assignees` | true     | Comma separated list of user names. Issue will be assigned to those users. |
 
 ## Example usage
 
@@ -25,7 +24,6 @@ jobs:
             - name: 'Auto-assign issue'
               uses: pozil/auto-assign-issue@v1
               with:
-                  repo-token: ${{ github.token }}
                   assignees: octocat
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const run = async () => {
         `Assigning issue ${issue.number} to users ${JSON.stringify(assignees)}`
     );
     try {
-        await octokit.issues.addAssignees({
+        await octokit.rest.issues.addAssignees({
             owner,
             repo,
             issue_number: issue.number,


### PR DESCRIPTION
Looks like a dependency bump changed the octokit API which broke this action.  This fixes it.

I also cleaned up the readme to no longer reference the repo-token since most users won't need to specify it and if they really need it, the action.yml still shows how to use it.