### PR TITLE
Add support for assigning pull requests

### DIFF
--- a/src/__tests__/action.test.js
+++ b/src/__tests__/action.test.js
@@ -12,6 +12,10 @@ const CONTEXT_PAYLOAD = {
     repository: { full_name: 'mockOrg/mockRepo' },
     issue: { number: 666 }
 };
+const PR_CONTEXT_PAYLOAD = {
+    repository: { full_name: 'mockOrg/mockRepo' },
+    issue: { number: 666 }
+};
 
 // Mock Octokit
 const assignUsersToIssueMock = jest.fn(() => Promise.resolve());
@@ -170,6 +174,25 @@ describe('action', () => {
             expect(
                 assignUsersToIssueMock.mock.calls[0][0].assignees.length
             ).toBe(2);
+        });
+
+        it('works with pull requests', async () => {
+            await runAction(
+                octokitMock,
+                PR_CONTEXT_PAYLOAD,
+                'user1,user2',
+                null,
+                null
+            );
+
+            expect(listTeamMembersMock).not.toHaveBeenCalled();
+            expect(assignUsersToIssueMock).toHaveBeenCalledTimes(1);
+            expect(assignUsersToIssueMock).toHaveBeenCalledWith({
+                assignees: ['user1', 'user2'],
+                issue_number: 666,
+                owner: 'mockOrg',
+                repo: 'mockRepo'
+            });
         });
     });
 });

--- a/src/action.js
+++ b/src/action.js
@@ -46,7 +46,10 @@ const runAction = async (
     numOfAssigneeString
 ) => {
     // Get repo and issue info from context
-    const { repository, issue } = context;
+    const { repository } = context;
+
+    const issue = context.issue || context.pull_request;
+
     if (!issue) {
         throw new Error(`Couldn't find issue info in current context`);
     }


### PR DESCRIPTION
Hi, thanks for creating this action, it's been really useful for us so far!

Something we want to do is to use it to auto-assign PRs from external contributors. Since GitHub treats PRs as issues, only a minor change is needed to allow this action to support them.