### PR TITLE
Fixing error on nested event and optional chaining on node (upgrading node version)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
         required: false
 
 runs:
-    using: 'node12'
+    using: 'node14'
     main: 'src/index.js'
 
 branding:

--- a/src/__tests__/action.test.js
+++ b/src/__tests__/action.test.js
@@ -19,11 +19,9 @@ const PR_CONTEXT_PAYLOAD = {
 
 const PROJECT_CONTEXT_PAYLOAD = {
     repository: { full_name: 'mockOrgCard/mockRepoCard' },
-    event: {
-        project_card: {
-            content_url:
-                'https://github.com/mockOrgCard/mockRepoCard/issues/668'
-        }
+    project_card: {
+        content_url:
+            'https://github.com/mockOrgCard/mockRepoCard/issues/668'
     }
 };
 

--- a/src/action.js
+++ b/src/action.js
@@ -55,16 +55,17 @@ const runAction = async (
     // If the issue is not found directly, maybe it came for a card movement with a linked issue
     if (
         !issue &&
-        context?.event?.project_card?.content_url?.includes('issues')
+        context?.project_card?.content_url?.includes('issues')
     ) {
         const contentUrlParts =
-            context.event.project_card.content_url.split('/');
+            context.project_card.content_url.split('/');
         issue = parseInt(contentUrlParts[contentUrlParts.length - 1], 10);
     }
 
     if (!issue) {
         throw new Error(`Couldn't find issue info in current context`);
     }
+
 
     const [owner, repo] = repository.full_name.split('/');
     // Check params


### PR DESCRIPTION
I checked there was a typo adding a non valid nested level - I also fixed it in the test section.

On the other hand, I discovered this issue because the action was failing due to my PR and to this change: https://github.com/pozil/auto-assign-issue/commit/78eb641d713deb2a3478b525e93c28f044919dff#diff-3eff2eb784c259a70aa99b331bdf2de36ef13b78240a7789e3e530e0f639f817R53.

The optional chaining was supported on NodeJS 14, that's why this version is failing (is using nodejs 12).

Thanks