### PR TITLE
Bumping node16 version because seems node14 fails

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
         required: false
 
 runs:
-    using: 'node14'
+    using: 'node16'
     main: 'src/index.js'
 
 branding:


### PR DESCRIPTION
After bumping into node14 seems an error appeared:

`Parameter ''using: node14' is not supported, use 'docker', 'node12' or 'node16' instead.')`

Seemed to be supported but seems [it's not](https://github.com/actions/runner/issues/772).

