### PR TITLE
Ensuring a PR cannot be assigned to the creator

### DIFF
--- a/src/__tests__/action.test.js
+++ b/src/__tests__/action.test.js
@@ -249,7 +249,7 @@ describe('action', () => {
             expect(listTeamMembersMock).not.toHaveBeenCalled();
             expect(addPRReviewersMock).toHaveBeenCalledTimes(1);
             expect(addPRReviewersMock).toHaveBeenCalledWith({
-                requested_reviewers: ['user1', 'user2'],
+                reviewers: ['user1', 'user2'],
                 pull_number: 667,
                 owner: 'mockOrg',
                 repo: 'mockRepo'

--- a/src/action.js
+++ b/src/action.js
@@ -191,8 +191,8 @@ const runAction = async (octokit, context, parameters) => {
     // Remove duplicates from assignees
     assignees = [...new Set(assignees)];
 
-    // Remove author if allowSelfAssign is disabled
-    if (!allowSelfAssign) {
+    // Remove author if allowSelfAssign is disabled OR if it's a PR (where it's not allowed).
+    if (!allowSelfAssign || !isIssue) {
         const foundIndex = assignees.indexOf(author);
         if (foundIndex !== -1) {
             assignees.splice(foundIndex, 1);
@@ -236,11 +236,12 @@ const runAction = async (octokit, context, parameters) => {
         console.log(
             `Assigning PR ${issueNumber} to users ${JSON.stringify(assignees)}`
         );
+
         await octokit.rest.pulls.requestReviewers({
             owner,
             repo,
             pull_number: issueNumber,
-            requested_reviewers: assignees
+            reviewers: assignees
         });
     }
 };


### PR DESCRIPTION
I checked in repositories with not too many people, the probability to assign the PR to the creator is too high. Adding a way to exclude the author by using the _allowSelfAssign_ implementation and adding a new condition in the if flow remove the author from the asignees list.

On the other hand, fixing the payload when requesting the POST action to assign reviewers. A false positive was being raised in the GH result but after testing with postman it worked.

The tests were adapted too.