### PR TITLE
Adding a workaround to work with public or private repos for PRs

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -65,7 +65,9 @@ const isAnIssue = async (octokit, owner, repo, issue_number) => {
             repo,
             issue_number
         });
-        if (issue?.data) {
+        // In private repos, an exception is raised. In public ones, extra info comes.
+        if (!issue?.data?.pull_request) {
+            // if the pull_request node comes, it means is non a real issue, it is a PR
             isAnIssue = true;
         }
     } catch (err) {


### PR DESCRIPTION
When a PR is created, it comes as a PR. When a card is moved, it has linked an issue and that was the motivation to create the method to check if it's a real issue or not (so it was a PR). In all the previous tests, it worked because the repository was private and when the issue was a PR, an exception was raised.

On the other hand, when using public repos, instead of getting an exception in the octokit implementation, a reponse is gotten with an extra attribute called _pull_request_. Without this the action works but not in public repositories at all.

I checked it by using: `uses: agomezmoron/auto-assign-issue@fix/support-checking-issue-pr-any-repo` and worked like a charm in public or private repos.

With this I'm sure we close the PR full support.