### PR TITLE
Handle workflow run

### DIFF
--- a/src/__tests__/action.test.js
+++ b/src/__tests__/action.test.js
@@ -336,5 +336,36 @@ describe('action', () => {
                 assignees: ['userA', 'userB']
             });
         });
+
+        it('assigns author to pull request assignee', async () => {
+            await runAction(octokitMock, PR_CONTEXT_PAYLOAD, {
+                assigneesString: 'author,user1,user2',
+                allowSelfAssign: true
+            });
+
+            expect(listTeamMembersMock).not.toHaveBeenCalled();
+            expect(addIssueAssigneesMock).toHaveBeenCalledTimes(1);
+            expect(addIssueAssigneesMock).toHaveBeenCalledWith({
+                assignees: ['author', 'user1', 'user2'],
+                issue_number: 667,
+                owner: 'mockOrg',
+                repo: 'mockRepo'
+            });
+        });
+
+        it('does not assigns author to pull request reviewer', async () => {
+            await runAction(octokitMockForPRs, PR_CONTEXT_PAYLOAD, {
+                assigneesString: 'author,user1,user2',
+                allowSelfAssign: true
+            });
+
+            expect(addPRReviewersMock).toHaveBeenCalledTimes(1);
+            expect(addPRReviewersMock).toHaveBeenCalledWith({
+                reviewers: ['user1', 'user2'],
+                pull_number: 667,
+                owner: 'mockOrg',
+                repo: 'mockRepo'
+            });
+        });
     });
 });

--- a/src/__tests__/action.test.js
+++ b/src/__tests__/action.test.js
@@ -198,7 +198,7 @@ describe('action', () => {
             });
         });
 
-        it('works with asignees only, no random pick', async () => {
+        it('works with assignees only, no random pick', async () => {
             await runAction(octokitMock, CONTEXT_PAYLOAD, {
                 assigneesString: 'user1,user2'
             });

--- a/src/action.js
+++ b/src/action.js
@@ -209,8 +209,8 @@ const runAction = async (octokit, context, parameters) => {
     // Remove duplicates from assignees
     assignees = [...new Set(assignees)];
 
-    // Remove author if allowSelfAssign is disabled OR if it's a PR (where it's not allowed).
-    if (!allowSelfAssign || !isIssue) {
+    // Remove author if allowSelfAssign is disabled
+    if (!allowSelfAssign) {
         const foundIndex = assignees.indexOf(author);
         if (foundIndex !== -1) {
             assignees.splice(foundIndex, 1);

--- a/src/action.js
+++ b/src/action.js
@@ -127,10 +127,15 @@ const runAction = async (octokit, context, parameters) => {
     } = parameters;
 
     // Get issue info from context
-    let issueNumber = context.issue?.number || context.pull_request?.number;
+    let issueNumber =
+        context.issue?.number ||
+        context.pull_request?.number ||
+        context.workflow_run?.pull_requests[0].number;
     let isIssue = context.issue ? true : false;
     const author =
-        context.issue?.user.login || context.pull_request?.user.login;
+        context.issue?.user.login ||
+        context.pull_request?.user.login ||
+        context.workflow_run?.actor.login;
 
     // If the issue is not found directly, maybe it came for a card movement with a linked issue
     if (

--- a/src/action.js
+++ b/src/action.js
@@ -242,16 +242,20 @@ const runAction = async (octokit, context, parameters) => {
 
     // Assign PR reviewers
     if (!isIssue) {
-        console.log(
-            `Assigning PR ${issueNumber} to users ${JSON.stringify(assignees)}`
-        );
+        if (assignees.length > 0) {
+            console.log(
+                `Assigning PR ${issueNumber} to users ${JSON.stringify(
+                    assignees
+                )}`
+            );
 
-        await octokit.rest.pulls.requestReviewers({
-            owner,
-            repo,
-            pull_number: issueNumber,
-            reviewers: assignees
-        });
+            await octokit.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number: issueNumber,
+                reviewers: assignees
+            });
+        }
     }
 };
 

--- a/src/action.js
+++ b/src/action.js
@@ -236,23 +236,22 @@ const runAction = async (octokit, context, parameters) => {
             issue_number: issueNumber,
             assignees
         });
-        if (!isIssue) {
-            // Assign PR reviewers
-            console.log(
-                `Assigning PR ${issueNumber} to users ${JSON.stringify(
-                    assignees
-                )}`
-            );
-
-            await octokit.rest.pulls.requestReviewers({
-                owner,
-                repo,
-                pull_number: issueNumber,
-                reviewers: assignees
-            });
-        }
     } else if (!allowNoAssignees) {
-        throw new Error('No candidates found for assignement');
+        throw new Error('No candidates found for assignment');
+    }
+
+    // Assign PR reviewers
+    if (!isIssue) {
+        console.log(
+            `Assigning PR ${issueNumber} to users ${JSON.stringify(assignees)}`
+        );
+
+        await octokit.rest.pulls.requestReviewers({
+            owner,
+            repo,
+            pull_number: issueNumber,
+            reviewers: assignees
+        });
     }
 };
 

--- a/src/action.js
+++ b/src/action.js
@@ -242,6 +242,12 @@ const runAction = async (octokit, context, parameters) => {
 
     // Assign PR reviewers
     if (!isIssue) {
+        // Remove author from reviewers
+        const foundIndex = assignees.indexOf(author);
+        if (foundIndex !== -1) {
+            assignees.splice(foundIndex, 1);
+        }
+
         if (assignees.length > 0) {
             console.log(
                 `Assigning PR ${issueNumber} to users ${JSON.stringify(


### PR DESCRIPTION
This PR updates the action to handle the assignment of PRs and issues to users when triggered from a `workflow_run`. 

It also fixes the action to allow authors to be assigned to PRs that they have created but does not allow them to be assigned as a reviewer. 