### PR TITLE
Add support for passing issue ID manually.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
         description: 'Flag that allows self-assignment to the issue author.'
         required: false
         default: true
+    issueNumber:
+        description: 'Manually specified issue (or PR) ID to be used instead of the one in the context.'
+        required: false
 
 runs:
     using: 'node16'

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,20 @@ try {
         required: false
     });
 
+    let manualIssueNumber;
+    try {
+        manualIssueNumber = parseIntInput(
+            core.getInput('issueNumber', {
+                require: false
+            }),
+            0
+        );
+    } catch (error) {
+        throw new Error(
+            `Failed to parse value for issueNumber: ${error.message}`
+        );
+    }
+
     // Get octokit
     const octokit = github.getOctokit(gitHubToken);
 
@@ -53,7 +67,8 @@ try {
         abortIfPreviousAssignees,
         removePreviousAssignees,
         allowNoAssignees,
-        allowSelfAssign
+        allowSelfAssign,
+        manualIssueNumber
     });
 } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
As per https://securitylab.github.com/research/github-actions-preventing-pwn-requests/, we would like to securely auto assign user to the PR from the external forks.

This change allows optional explicit issue ID to be passed, useful when context is missing. See example usage in https://github.com/GoogleCloudPlatform/prometheus-engine/pull/532