### PR TITLE
doc: fix permissions in pr example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
     auto-assign:
         runs-on: ubuntu-latest
         permissions:
-            issues: write
+            pull-requests: write
         steps:
             - name: 'Auto-assign PR'
               uses: pozil/auto-assign-issue@v2


### PR DESCRIPTION
Assigning PRs only works if the job has write access to pull requests.